### PR TITLE
Add 'tacome [zipcode]' to ccbot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,49 @@
 
 SoCal Code Camp Slack bot - https://www.socalcodecamp.com/
 
-
-### Installation
+## Installation
 
 In order to use ccbot with slack, you need to create a [slack app](https://api.slack.com/apps?new_app=1). After creating an app, you need to get you API Token. That token needs to be added to an environment variable named 'SLACK_CODE_CAMP_BOT_TOKEN'
 
 Install deps : 
 
-    pip install -r requirements.text 
+    `pip install -r requirements.text` 
 
 Start bot:
 
-    ccbot/bot
-    
+    `ccbot/bot`
+
 The bot should be up and running.
 
 Note: If you would like the bot to work in private channels, you need to invite the bot to the channel.
 
-### Unit Tests
+## Unit Tests
+
 Run tests (from root of the project):
 
-    pytest 
+    `pytest` 
 
 To run tests continuously via [pytest-watch](https://github.com/joeyespo/pytest-watch):
 
-    ptw
+    `ptw`
 
 ### Code Coverage
 
-    ./cover.sh
+    `./cover.sh`
 
-### Adding new Commands
+## Adding new Commands
+
 Commands are automaticatlly loaded at startup. To add a new command, add a class in the commands folder. The class must include
 the following 3 method:
 
-* get_channel_id(self):<Br/>
-returns the channel ID where this command can execute. It can also be "all" for all public channels and private channels that ccbot is a member of.
+| Method | Description |
+|---    |---    |
+|`get_channel_id(self)`|Returns the channel ID where this command can execute. It can also be "all" for any public or private channels which have ccbot as a member.|
+|`invoke(self, command, user)`| This method gets called everytime someone invokes the command. The `command` parameter contains the name of the command, and any other trailing arguments as a single string.|
+|`get_command(self)`|Text used to invoke command. The input can contain other characters after the command text.|
 
-* invoke(self, command, user)<Br/>
- This method gets called everytime someone invokes the command.
-  
-* get_command(self):<Br/>
-Text used to invoke command. The input can contain other characters after the command text.
+## Current Command List
 
-### Current Command List
 * catme - shows a catgif from [Edgecats](http://edgecats.net/)
 * dogme - shows an image of a puppy
 * goatme - shows an image of a goat
@@ -54,12 +53,10 @@ Text used to invoke command. The input can contain other characters after the co
 * teslame - shows an image of an [intergallatic spaceboat of light and wonder](http://theoatmeal.com/comics/tesla_model_s). Note: It's TeslaME not tesLAME.
 * earthme - shows an image of the earth.
 * xkcd - shows a random xkcd comic
-    * xkcd latest - shows the most recent xkcd comic
-    * xkcd [number] - shows an xkcd comic by it's id. eg "xkcd 221" (which is one of my favorites)
+  * xkcd latest - shows the most recent xkcd comic
+  * xkcd [number] - shows an xkcd comic by it's id. eg "xkcd 221" (which is one of my favorites)
+* tacome [zip code] - shows a random yelp business categorized 'tacotrucks' with term 'taco'
 * ccbot - generic ccbot command. ccbot must be invoked with a command in the form ccbot [command]. Commands are mapped to functions that start with "action_"
-   * ccbot tell_joke - grabs a dad joke and displays the text
-    
- ![Image of ccbot invoking earthme and xkcd](https://i.imgur.com/Pol1L0l.png)
+  * ccbot tell_joke - grabs a dad joke and displays the text
 
-  
- 
+![Image of ccbot invoking earthme and xkcd](https://i.imgur.com/Pol1L0l.png)

--- a/ccbot/commands/TacoMe.py
+++ b/ccbot/commands/TacoMe.py
@@ -1,0 +1,49 @@
+import os
+from services.api_client import ApiClient
+from services.slack_response import SlackResponse
+from utils.cache import *
+from urllib2 import *
+
+
+class TacoMe:
+    url = "https://api.yelp.com/v3/businesses/search?term=taco&sort_by=distance&categories=foodtrucks&location=90405"
+    api_client = None
+
+    def __init__(self):
+        self.api_client = ApiClient()
+        self.api_headers = {
+            'Accept': 'application/json',
+            'Authorization': self.get_auth_value()
+        }
+
+    def get_channel_id(self):
+        return "all"
+
+    def get_auth_value(self):
+        token = os.environ.get('SLACK_CODE_CAMP_BOT_YELP_TOKEN')
+        return 'Bearer ' + token if token else None
+
+    def get_data(self):
+        return self.api_client.fetch(self.url, headers=self.api_headers)
+
+    def invoke(self, command, user):
+        try:
+            result = self.get_data()
+        except HTTPError as he:
+            return SlackResponse.text(str(he))
+        except URLError as ue:
+            return SlackResponse.text(str(e.args))
+
+        if (result['total'] == 0):
+            return SlackResponse.text('Sorry, no taco for ' + command)
+
+        found = result['businesses'][0]
+        description = 'Rated %s by %s people, is %s meters away price level %s' % (
+            found['rating'], found['review_count'], found['distance'], found['price'])
+        return SlackResponse.attachment(
+            title=found['name'],
+            image_url=found['image_url'],
+            text=description)
+
+    def get_command(self):
+        return "tacome"

--- a/ccbot/commands/TacoMe.py
+++ b/ccbot/commands/TacoMe.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import re
 import os
 from services.api_client import ApiClient
@@ -47,12 +48,12 @@ class TacoMe:
         except URLError as ue:
             return SlackResponse.text(str(ue.args))
 
-        if (result['total'] == 0):
-            return SlackResponse.text('Sorry, no taco for ' + command)
-
         return self.create_slack_response(result)
 
     def create_slack_response(self, api_response):
+        if (api_response['total'] == 0):
+            return SlackResponse.text('No taco ¯\\_(ツ)_/¯')
+
         found = random.choice(api_response['businesses'])
         
         description = 'Rated %s by %s people, is %s meters away' % (

--- a/ccbot/commands/TacoMe.py
+++ b/ccbot/commands/TacoMe.py
@@ -1,12 +1,12 @@
+import re
 import os
 from services.api_client import ApiClient
 from services.slack_response import SlackResponse
 from utils.cache import *
 from urllib2 import *
 
-
 class TacoMe:
-    url = "https://api.yelp.com/v3/businesses/search?term=taco&sort_by=distance&categories=foodtrucks&location=90405"
+    url = "https://api.yelp.com/v3/businesses/search?term=taco&sort_by=distance&categories=foodtrucks&location="
     api_client = None
 
     def __init__(self):
@@ -15,6 +15,7 @@ class TacoMe:
             'Accept': 'application/json',
             'Authorization': self.get_auth_value()
         }
+        self.zipcode_re = re.compile(r'^tacome\s+(\d{5})\s*$')
 
     def get_channel_id(self):
         return "all"
@@ -23,23 +24,43 @@ class TacoMe:
         token = os.environ.get('SLACK_CODE_CAMP_BOT_YELP_TOKEN')
         return 'Bearer ' + token if token else None
 
-    def get_data(self):
-        return self.api_client.fetch(self.url, headers=self.api_headers)
+    def get_zipcode(self, command):
+        matched = self.zipcode_re.match(command)
+        return matched.group(1) if matched else None
+
+    def get_data(self, url):
+        return self.api_client.fetch(url, headers=self.api_headers)
 
     def invoke(self, command, user):
+
+        zip = self.get_zipcode(command)
+
+        if(zip is None):
+            return SlackResponse.text(r'Try: `tacome _ZIP_CODE_`. Example: `tacome 90405`')
+
+        url = self.url+zip
+        
         try:
-            result = self.get_data()
+            result = self.get_data(url)
         except HTTPError as he:
             return SlackResponse.text(str(he))
         except URLError as ue:
-            return SlackResponse.text(str(e.args))
+            return SlackResponse.text(str(ue.args))
 
         if (result['total'] == 0):
             return SlackResponse.text('Sorry, no taco for ' + command)
 
-        found = result['businesses'][0]
-        description = 'Rated %s by %s people, is %s meters away price level %s' % (
-            found['rating'], found['review_count'], found['distance'], found['price'])
+        return self.create_slack_response(result)
+
+    def create_slack_response(self, api_response):
+        found = random.choice(api_response['businesses'])
+        
+        description = 'Rated %s by %s people, is %s meters away' % (
+            found['rating'],
+            found['review_count'],
+            int(found['distance'])
+            )
+
         return SlackResponse.attachment(
             title=found['name'],
             image_url=found['image_url'],

--- a/tests/test_tacome.py
+++ b/tests/test_tacome.py
@@ -6,22 +6,51 @@ sys.path.append("ccbot")
 from ccbot.commands.TacoMe import TacoMe
 from ccbot.services.api_client import *
 from services.slack_response import SlackResponse
-from mock import MagicMock,patch
+from mock import MagicMock, patch
 
 COMMAND = 'tacome 90405'
 
+
 def test_commandtext_is_tacome():
     assert TacoMe().get_command() == "tacome"
+
 
 def test_available_in_all_channels():
     assert TacoMe().get_channel_id() == "all"
 
 
-def test_invoke_returns_title():
+def test_invoke_without_zip_returns_suggestion():
+    result = TacoMe().invoke("tacome", "fake_user")
+    assert result[0] == 'Try: `tacome _ZIP_CODE_`. Example: `tacome 90405`'
+
+
+
+def test_invoke_returns_attachment():
     result = TacoMe().invoke(COMMAND, "fake_user")
     for entry in ('title', 'image_url', 'text'):
         assert result[1][0][entry]
 
+
 def test_get_auth_value_returns_bearer():
     result = TacoMe().get_auth_value()
     assert result.startswith('Bearer ')
+
+
+def test_get_zipcode_extracts_5digits():
+    cases = {
+        'tacome': None,
+        'tacome 12345': '12345',
+        'tacome   12345': '12345',
+        'tacome   12345   ': '12345',
+        'tacome 1234': None,
+        'tacome 123456': None,
+        'tacome a 123456': None,
+
+    }
+    
+    for command,expected in cases.iteritems():
+        actual = TacoMe().get_zipcode(command)
+        if (expected is None):
+                assert actual is None
+        else:
+                assert actual == expected 

--- a/tests/test_tacome.py
+++ b/tests/test_tacome.py
@@ -1,0 +1,27 @@
+import random
+import sys
+
+sys.path.append("ccbot")
+
+from ccbot.commands.TacoMe import TacoMe
+from ccbot.services.api_client import *
+from services.slack_response import SlackResponse
+from mock import MagicMock,patch
+
+COMMAND = 'tacome 90405'
+
+def test_commandtext_is_tacome():
+    assert TacoMe().get_command() == "tacome"
+
+def test_available_in_all_channels():
+    assert TacoMe().get_channel_id() == "all"
+
+
+def test_invoke_returns_title():
+    result = TacoMe().invoke(COMMAND, "fake_user")
+    for entry in ('title', 'image_url', 'text'):
+        assert result[1][0][entry]
+
+def test_get_auth_value_returns_bearer():
+    result = TacoMe().get_auth_value()
+    assert result.startswith('Bearer ')

--- a/tests/test_tacome.py
+++ b/tests/test_tacome.py
@@ -1,10 +1,11 @@
 import random
 import sys
+import os
 
 sys.path.append("ccbot")
 
 from ccbot.commands.TacoMe import TacoMe
-from ccbot.services.api_client import *
+# from ccbot.services.api_client import *
 from ccbot.services.slack_response import SlackResponse
 from mock import MagicMock, patch
 import pytest
@@ -46,9 +47,11 @@ class TacoMeTest(unittest.TestCase):
         for entry in ('title', 'image_url', 'text'):
             assert actual[1][0][entry]
 
-    def test_get_auth_value_returns_bearer(self):
+    @patch.object(os.environ, 'get')
+    def test_get_auth_value_returns_bearer(self,mock_get):
+        mock_get.return_value = '<API KEY>'
         result = TacoMe().get_auth_value()
-        assert result.startswith('Bearer ')
+        assert result == 'Bearer <API KEY>'
 
     def test_get_zipcode_extracts_5digits(self):
         cases = {

--- a/tests/test_tacome.py
+++ b/tests/test_tacome.py
@@ -5,52 +5,65 @@ sys.path.append("ccbot")
 
 from ccbot.commands.TacoMe import TacoMe
 from ccbot.services.api_client import *
-from services.slack_response import SlackResponse
+from ccbot.services.slack_response import SlackResponse
 from mock import MagicMock, patch
+import pytest
+import unittest
 
-COMMAND = 'tacome 90405'
-
-
-def test_commandtext_is_tacome():
-    assert TacoMe().get_command() == "tacome"
-
-
-def test_available_in_all_channels():
-    assert TacoMe().get_channel_id() == "all"
-
-
-def test_invoke_without_zip_returns_suggestion():
-    result = TacoMe().invoke("tacome", "fake_user")
-    assert result[0] == 'Try: `tacome _ZIP_CODE_`. Example: `tacome 90405`'
+ZIP = '90405'
+COMMAND = 'tacome ' + ZIP
+API_RESPONSE_SAMPLE = {'businesses': [
+    {
+        'name': 'marklar', 
+        'image_url': 'https://taco.pic/1', 
+        'rating': 1, 
+        'review_count': 2, 
+        'distance': 3}]}
 
 
+class TacoMeTest(unittest.TestCase):
 
-def test_invoke_returns_attachment():
-    result = TacoMe().invoke(COMMAND, "fake_user")
-    for entry in ('title', 'image_url', 'text'):
-        assert result[1][0][entry]
+    def test_commandtext_is_tacome(self):
+        assert TacoMe().get_command() == "tacome"
 
+    def test_available_in_all_channels(self):
+        assert TacoMe().get_channel_id() == "all"
 
-def test_get_auth_value_returns_bearer():
-    result = TacoMe().get_auth_value()
-    assert result.startswith('Bearer ')
+    def test_invoke_without_zip_returns_suggestion(self):
+        result = TacoMe().invoke("tacome", "fake_user")
+        assert result[0] == 'Try: `tacome _ZIP_CODE_`. Example: `tacome 90405`'
 
+    @patch.object(TacoMe, 'get_data')
+    def test_invoke_calls_get_data(self, get_data):
+        get_data.return_value = {'total': 0}
+        TacoMe().invoke(COMMAND, "fake_user")
+        expected = "https://api.yelp.com/v3/businesses/search?term=taco&sort_by=distance&categories=foodtrucks&location=" + ZIP
 
-def test_get_zipcode_extracts_5digits():
-    cases = {
-        'tacome': None,
-        'tacome 12345': '12345',
-        'tacome   12345': '12345',
-        'tacome   12345   ': '12345',
-        'tacome 1234': None,
-        'tacome 123456': None,
-        'tacome a 123456': None,
+        get_data.assert_called_with(expected)
 
-    }
-    
-    for command,expected in cases.iteritems():
-        actual = TacoMe().get_zipcode(command)
-        if (expected is None):
+    def test_create_slack_response_populates_attachment(self):
+        actual = TacoMe().create_slack_response(API_RESPONSE_SAMPLE)
+        for entry in ('title', 'image_url', 'text'):
+            assert actual[1][0][entry]
+
+    def test_get_auth_value_returns_bearer(self):
+        result = TacoMe().get_auth_value()
+        assert result.startswith('Bearer ')
+
+    def test_get_zipcode_extracts_5digits(self):
+        cases = {
+            'tacome': None,
+            'tacome 12345': '12345',
+            'tacome   12345': '12345',
+            'tacome   12345   ': '12345',
+            'tacome 1234': None,
+            'tacome 123456': None,
+            'tacome a 123456': None
+        }
+
+        for command, expected in cases.iteritems():
+            actual = TacoMe().get_zipcode(command)
+            if (expected is None):
                 assert actual is None
-        else:
-                assert actual == expected 
+            else:
+                assert actual == expected


### PR DESCRIPTION
Adds a `tacome` command that takes a zipcode as a single argument. Returns a random item based on a Yelp API call.

> Requires an environment variable _SLACK_CODE_CAMP_BOT_YELP_TOKEN_ containing a Yelp API auth key.


Example usage: 

"tacome 90290"